### PR TITLE
Add TrackingAccuracy and position/rotation device properties

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/Headset.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/Headset.cs
@@ -22,14 +22,34 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
         public SDKType HeadsetSDKType { get; set; }
 
         /// <summary>
+        /// Indicates whether or not the headset is currently providing position data.
+        /// </summary>
+        public bool IsPositionAvailable { get; set; }
+
+        /// <summary>
         /// Outputs the current position of the headset, as defined by the SDK / Unity.
         /// </summary>
         public Vector3 Position { get; set; }
 
         /// <summary>
+        /// Indicates the accuracy of the position data being reported.
+        /// </summary>
+        public TrackingAccuracy PositionAccuracy { get; set; }
+
+        /// <summary>
+        /// Indicates whether or not the headset is currently providing rotation data.
+        /// </summary>
+        public bool IRotatioinAvailable { get; set; }
+
+        /// <summary>
         /// Outputs the current rotation of the headset, as defined by the SDK / Unity.
         /// </summary>
         public Quaternion Rotation { get; set; }
+
+        /// <summary>
+        /// Indicates the accuracy of the rotation data being reported.
+        /// </summary>
+        public TrackingAccuracy RotationAccuracy { get; set; }
 
         /// <summary>
         /// Outputs the current state of the headset, whether it is tracked or not. As defined by the SDK / Unity.

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/TrackingAccuracy.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/TrackingAccuracy.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
+{
+    /// <summary>
+    /// The Tracking Accuracy defines how well a device (ex: controller or headset) is currently 
+    /// being tracked. This enables developers to respond to various situations and react accordingly.
+    /// </summary>
+    public enum TrackingAccuracy
+    {
+        /// <summary>
+        /// There is no accuracy data for this device.
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// The device is returning it's most accurate data.
+        /// </summary>
+        High,
+        /// <summary>
+        /// The device is returning it's medium level of accuracy.
+        /// </summary>
+        Medium,
+        /// <summary>
+        /// The device is returning it's low level of accuracy.
+        /// </summary>
+        Low,
+        /// <summary>
+        /// The device is returning approximate tracking data.
+        /// </summary>
+        /// <remarks>
+        /// Approximate accuracy generally implies that the device is not
+        /// visible to sensors and that the system is inferring the data by
+        /// other means.
+        /// </remarks>
+        Approximate
+    }
+}

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/TrackingAccuracy.cs.meta
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/TrackingAccuracy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ff245779db02774fac799b8c9a2277d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ce0387fe0b4c824aa16dee6d56afd96, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Devices/TrackingState.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Devices/TrackingState.cs
@@ -4,26 +4,26 @@
 namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Devices
 {
     /// <summary>
-    /// The Tracking State defines how a controller or headset is currently being tracked.
-    /// This enables developers to be able to handle non-tracked situations and react accordingly
+    /// The Tracking State defines how a device is currently being tracked.
+    /// This enables developers to be able to handle non-tracked situations and react accordingly.
     /// </summary>
     public enum TrackingState
     {
         /// <summary>
-        /// The controller is currently not tracked.
+        /// The device does not support the concept of tracking.
         /// </summary>
-        NotTracked = 0,
-        /// <summary>
-        /// The controller is tracked, but has approximate positioning.
-        /// </summary>
-        Approximate,
-        /// <summary>
-        /// The controller is currently fully tracked and has accurate positioning.
-        /// </summary>
-        Tracked,
+        None = 0,
         /// <summary>
         /// Reserved, for systems that provide alternate tracking.
         /// </summary>
         Other,
+        /// <summary>
+        /// The device is currently not tracked.
+        /// </summary>
+        NotTracked,
+        /// <summary>
+        /// The device is currently tracked.
+        /// </summary>
+        Tracked,
     }
 }

--- a/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/MixedRealityPose.cs
+++ b/Assets/MixedRealityToolkit/_Core/Definitions/Utilities/MixedRealityPose.cs
@@ -25,21 +25,15 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Definitions.Utilities
         /// Constructor.
         /// </summary>
         /// <param name="position"></param>
-        public MixedRealityPose(Vector3 position)
-        {
-            this.position = position;
-            rotation = Quaternion.identity;
-        }
+        public MixedRealityPose(Vector3 position) : this(position, Quaternion.identity)
+        { }
 
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="rotation"></param>
-        public MixedRealityPose(Quaternion rotation)
-        {
-            position = Vector3.zero;
-            this.rotation = rotation;
-        }
+        public MixedRealityPose(Quaternion rotation) : this(Vector3.zero, rotation)
+        { }
 
         /// <summary>
         /// The default value for a Six Dof Transform.

--- a/Assets/MixedRealityToolkit/_Core/Devices/BaseController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Devices/BaseController.cs
@@ -23,13 +23,38 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices
         /// <param name="controllerHandedness"></param>
         /// <param name="inputSource"></param>
         /// <param name="interactions"></param>
-        protected BaseController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource = null, MixedRealityInteractionMapping[] interactions = null)
+        protected BaseController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource, MixedRealityInteractionMapping[] interactions)
         {
             TrackingState = trackingState;
             ControllerHandedness = controllerHandedness;
             InputSource = inputSource;
             Interactions = interactions;
+
+            // TODO: consider if these should be passed in or not
+            IsPositionAvailable = false;
+            PositionAccuracy = TrackingAccuracy.None;
+            IsRotationAvailable = false;
+            RotationAccuracy = TrackingAccuracy.None;
         }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="trackingState"></param>
+        /// <param name="controllerHandedness"></param>
+        /// <param name="inputSource"></param>
+        protected BaseController(TrackingState trackingState, Handedness controllerHandedness, IMixedRealityInputSource inputSource) :
+            this(trackingState, controllerHandedness, inputSource, null)
+        { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="trackingState"></param>
+        /// <param name="controllerHandedness"></param>
+        protected BaseController(TrackingState trackingState, Handedness controllerHandedness) : 
+            this(trackingState, controllerHandedness, null, null)
+        { }
 
         /// <summary>
         /// Returns the current Input System if enabled, otherwise null.
@@ -57,6 +82,18 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Devices
 
         /// <inheritdoc />
         public IMixedRealityInputSource InputSource { get; }
+
+        /// <inheritdoc />
+        public bool IsPositionAvailable { get; protected set; }
+
+        /// <inheritdoc />
+        public TrackingAccuracy PositionAccuracy { get; protected set; }
+
+        /// <inheritdoc />
+        public bool IsRotationAvailable { get; protected set; }
+
+        /// <inheritdoc />
+        public TrackingAccuracy RotationAccuracy { get; protected set; }
 
         /// <inheritdoc />
         public MixedRealityInteractionMapping[] Interactions { get; private set; }

--- a/Assets/MixedRealityToolkit/_Core/Interfaces/Devices/IMixedRealityController.cs
+++ b/Assets/MixedRealityToolkit/_Core/Interfaces/Devices/IMixedRealityController.cs
@@ -28,6 +28,34 @@ namespace Microsoft.MixedReality.Toolkit.Internal.Interfaces
         IMixedRealityInputSource InputSource { get; }
 
         /// <summary>
+        /// Indicates that this controller is currently providing position data.
+        /// </summary>
+        /// <remarks>
+        /// This value may change during usage for some controllers. As a best practice,
+        /// be sure to check this value before using position data.
+        /// </remarks>
+        bool IsPositionAvailable { get; }
+
+        /// <summary>
+        /// Indicates the accuracy of the position data being reported.
+        /// </summary>
+        TrackingAccuracy PositionAccuracy { get; }
+
+        /// <summary>
+        /// Indicates that this controller is currently providing rotation data.
+        /// </summary>
+        /// <remarks>
+        /// This value may change during usage for some controllers. As a best practice,
+        /// be sure to check this value before using rotation data.
+        /// </remarks>
+        bool IsRotationAvailable { get; }
+
+        /// <summary>
+        /// Indicates the accuracy of the rotation data being reported.
+        /// </summary>
+        TrackingAccuracy RotationAccuracy { get; }
+
+        /// <summary>
         /// Mapping definition for this controller, linking the Physical inputs to logical Input System Actions
         /// </summary>
         MixedRealityInteractionMapping[] Interactions { get; }


### PR DESCRIPTION
Overview
---
As tracking states are not hierarchical, we are simplifying the tracking check. Any form of tracking, positional, rotational, both will result in returning TrackingState.Tracked. To determine the position and orientation data availability and tracking accuracy, access the Headset struct and/or the IMixedRealityController interface.

I have also made some minor changes to some constructor overloads.

Changes
---
- Fixes: #2347
