### PR TITLE
Orientation was being reset right before the teleport was started

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -261,9 +261,6 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
             }
             else
             {
-                currentInputPosition = Vector2.zero;
-                PointerOrientation = 0f;
-
                 if (canTeleport)
                 {
                     canTeleport = false;


### PR DESCRIPTION
Orientation was being reset right before the teleport was started, so the handler in the teleport had the wrong orientation to set the rotation.