### PR TITLE
Updated angle math and removed the need for the 90 degree offset

### DIFF
--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Prefabs/Pointers/ParabolicPointer.prefab
@@ -435,7 +435,7 @@ MonoBehaviour:
     description: Teleport
     axisConstraint: 4
   inputThreshold: 0.5
-  angleOffset: 90
+  angleOffset: 0
   teleportActivationAngle: 45
   rotateActivationAngle: 22.5
   rotationAmount: 90

--- a/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
+++ b/Assets/MixedRealityToolkit-SDK/Features/UX/Scripts/Pointers/TeleportPointer.cs
@@ -274,7 +274,7 @@ namespace Microsoft.MixedReality.Toolkit.SDK.UX.Pointers
                 Mathf.Abs(currentInputPosition.x) > inputThreshold)
             {
                 // Get the angle of the pointer input
-                float angle = -Mathf.Atan2(currentInputPosition.y, currentInputPosition.x) * Mathf.Rad2Deg;
+                float angle = Mathf.Atan2(currentInputPosition.x, currentInputPosition.y) * Mathf.Rad2Deg;
 
                 // Offset the angle so it's 'forward' facing
                 angle += angleOffset;


### PR DESCRIPTION
The angle math doing a little more than it needed to. By swapping x and y, the negation and the 90 degree offset are now no longer needed. Since an angle of 0 is forward, this aligns with our determined teleport controls coordinate system.