### PR TITLE
fix mesh collection ro access

### DIFF
--- a/Assets/MixedRealityToolkit/_Core/DataProviders/SpatialObservers/BaseSpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/DataProviders/SpatialObservers/BaseSpatialObserver.cs
@@ -25,7 +25,11 @@ namespace Microsoft.MixedReality.Toolkit.Core.DataProviders.SpatialObservers
         public bool IsRunning { get; protected set; }
 
         /// <inheritdoc />
-        public virtual IReadOnlyDictionary<int, SpatialMeshObject> Meshes => new Dictionary<int, SpatialMeshObject>();
+        /// <remarks>
+        /// This method returns a copy of the collection maintained by the observer so that application
+        /// code can iterate through the collection without concern for changes to the backing data.
+        /// </remarks>
+        public virtual IReadOnlyDictionary<int, SpatialMeshObject> Meshes => new Dictionary<int, SpatialMeshObject>(SpatialMeshObjects);
 
         /// <inheritdoc />
         public virtual void StartObserving() { }

--- a/Assets/MixedRealityToolkit/_Core/DataProviders/SpatialObservers/WindowsMixedReality/WindowsMixedRealitySpatialObserver.cs
+++ b/Assets/MixedRealityToolkit/_Core/DataProviders/SpatialObservers/WindowsMixedReality/WindowsMixedRealitySpatialObserver.cs
@@ -111,9 +111,6 @@ namespace Microsoft.MixedReality.Toolkit.Core.DataProviders.SpatialObservers.Win
         /// </summary>
         private float lastUpdated = 0;
 
-        /// <inheritdoc />
-        public override IReadOnlyDictionary<int, SpatialMeshObject> Meshes => SpatialMeshObjects;
-
         /// <inheritdoc/>
         public override void StartObserving()
         {


### PR DESCRIPTION
Unfortunately, casting a collection to a ReadOnly collection does not protect the consumer from potential changes to the backing collection.

Updated to return a copy of the collection. Added < remarks > comment to explain.