### PR TITLE
Gltf nits

### DIFF
--- a/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scenes/Gltf-Loading-Demo.unity
+++ b/Assets/MixedRealityToolkit.Examples/Demos/Gltf/Scenes/Gltf-Loading-Demo.unity
@@ -328,7 +328,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e9fb424002a7044e91c26596ce40278, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  uri: \MixedRealityToolkit.Examples\Demos\Gltf\Models\Lantern\glTF\Lantern.gltf
+  uri: \GltfModels\Lantern\glTF\Lantern.gltf
 --- !u!1 &1486012704
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Overview
---
Two changes:
1) Fix gltf test unity scene to have correct file uri
2) Switch to a different png loading mechanism for gltf textures. Old mechanism threw an access denied based on opening a stream.

Changes
---
- Fixes: # .
